### PR TITLE
fix: update action name in Log emit for DFSBuy and DFSSell contracts

### DIFF
--- a/contracts/actions/exchange/DFSBuy.sol
+++ b/contracts/actions/exchange/DFSBuy.sol
@@ -101,7 +101,7 @@ contract DFSBuy is ActionBase, DFSExchangeCore {
         logger.Log(
             address(this),
             msg.sender,
-            "DfsBuy",
+            "DFSBuy",
             abi.encode(
                 wrapper,
                 _exchangeData.srcAddr,

--- a/contracts/actions/exchange/DFSSell.sol
+++ b/contracts/actions/exchange/DFSSell.sol
@@ -94,7 +94,7 @@ contract DFSSell is ActionBase, DFSExchangeCore {
         logger.Log(
             address(this),
             msg.sender,
-            "DfsSell",
+            "DFSSell",
             abi.encode(
                 wrapper,
                 _exchangeData.srcAddr,


### PR DESCRIPTION
The string parameter in the Log event is used to store the name of the action being executed.
The capitalization of action names isn't consistent in DFSBuy and DFSSell.
This merge would eliminate the need for the workaround in place in the dfs-recipe-info project (the existence of json/loggerActionIds.json).